### PR TITLE
slightly better init script...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ written in python, using `bottle` and `requests`.
 
 - `bottle` (Supplied with code, no need to install)
 - `requests` v2.1.14
+- `inotify-tools` (Install to OS)
 
 
 ## How to get up and running ?

--- a/init.sh
+++ b/init.sh
@@ -53,8 +53,7 @@ $(date) - - Started listening for changes...."
 function listen
 {
 
-	#[[ `which inotifywait` ]] && inotify_watch || legacy_watch
-	legacy_watch
+	[[ `which inotifywait` ]] && inotify_watch || legacy_watch
 }
 
 # Start script

--- a/init.sh
+++ b/init.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+
 [[ -f .env ]] && source ./.env
 
 FILE='src/index.py'
 INIT="bash -c 'DAFUQ_IS_WORDNIK_API_KEY=${DAFUQ_IS_WORDNIK_API_KEY} exec -a dafuqis-backend python3 ${FILE} &'"
+checksum=$(md5sum $FILE)
 
 function boot
 {
@@ -12,15 +14,47 @@ function boot
 	sleep 1
 }
 
-function listen
+function inotify_watch 
 {
+
 	echo "$(date) - - Starting listening for changes...."
+
     while inotifywait -q -r -e modify src/
     do   		
 		clear
 		echo "$(date) - - Change detected, restarting...."
 		boot
     done
+}
+
+function legacy_watch
+{
+	echo -e "Notice: inotifywait not found in your system. 
+- Using legacy method to restart 
+- Can restart only if change is detected in index.py. 
+- If you want to enjoy feature of restarting on any changes in the directory, then install inotifywait in your system.
+	
+$(date) - - Started listening for changes...."
+	
+	while true
+	do
+		checksum_new=$(md5sum $FILE)
+		if [ "$checksum" != "$checksum_new" ]
+		then
+			checksum=$checksum_new
+			echo "$(date) - - Change detected in $FILE, restarting...."
+			boot
+		fi
+		sleep 1
+	done
+}
+
+
+function listen
+{
+
+	#[[ `which inotifywait` ]] && inotify_watch || legacy_watch
+	legacy_watch
 }
 
 # Start script


### PR DESCRIPTION
This init script uses `inotifywait` from `inotify-tools` to check for changes in the whole `src` directory instead of just `src/index.py`.    

The process will be named as `dafuqis-backend` instead of `python3 src/index.py` in the running processes.  

For systems without `inotify`, the legacy watch feature still exists with a modification of checking file checksum instead of last modified date. This works only for `src/index.py` and not the whole `src/` folder.

This will also search for `.env` file before sourcing it. I hope to keep the app running in a default state even if there are no environment varialbes like WORDNIK API supplied.

